### PR TITLE
Update UCBR-0005_6-toegangscontrole.md

### DIFF
--- a/raadplegen/zorgkantoor/UCBR-0005_6-toegangscontrole.md
+++ b/raadplegen/zorgkantoor/UCBR-0005_6-toegangscontrole.md
@@ -24,7 +24,7 @@ N.b. Het valideren van de Acces-token door de PEP is geen onderdeel van de ze be
 
 ### **Context**
 - **Query-parameters vereist:** 
-  | QBR-0005-ZA                   | QBR-0006-ZA                   |
+  | QBR-0005-ZKu                   | QBR-0006-ZKu                   |
   | :---------------------------- | :---------------------------- |
   | - `bemiddelingspecificatieID` | - `bemiddelingspecificatieID` |
   | - `uitvoerendZorgkantoor`     | - `uitvoerendZorgkantoor`     |


### PR DESCRIPTION
typefout verbeterd bij de tabel met parameters QBR-0005-ZA gewijzigd in QBR-0005-ZKu en QBR-0006-ZA gewijzigd in QBR-0006-ZKu